### PR TITLE
fix(readme): s/npm run start/npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ basics to start development
 git clone <this repo url>
 cd <this repo dir>
 npm install
-npm run start
+npm start
 ```
 
 wait for a bit, then the browser will open to http://localhost:3000/# and you'll see the home screen.


### PR DESCRIPTION
`npm start` is a special command and does not require the `run` element to invoke!