### PR TITLE
Simplify the format of animations as received by WebAssembly Studio

### DIFF
--- a/src/utils/ModuleStore.js
+++ b/src/utils/ModuleStore.js
@@ -1,6 +1,6 @@
 import Constants from "../Constants";
 import AuthStore from "./AuthStore";
-import {data2png, makePNG, png2data} from './RenderUtils'
+import {data2pngs, pngs2data} from './RenderUtils'
 
 class ModuleStore {
   constructor() {
@@ -63,7 +63,7 @@ class ModuleStore {
           .then(res => {
               if(res.success) {
                   const anim = res.doc.manifest.animation
-                  return png2data(anim,anim.data).then((decoded) => {
+                  return pngs2data(anim,anim.data).then((decoded) => {
                       anim.data = decoded
                       return res.doc
                   })
@@ -90,7 +90,7 @@ class ModuleStore {
 
 
       const anim = module.manifest.animation
-      return data2png(anim,anim.data).then(pngs=>{
+      return data2pngs(anim,anim.data).then(pngs=>{
           anim.data = pngs
           return module
       }).then((module)=>{


### PR DESCRIPTION
Currently animations are encoded to JSON by WebAssembly Studio and then immediately decoded into ImageData objects by the website. This patch changes the website to expect a single ArrayBuffer containing the entire animation, which is what WebAssembly Studio uses internally.

On the WebAssembly Studio side the new format can be sent with a simple template change.

The patch also removes the rotation of incoming frames, as we can adapt the templates to not need that. In fact that's much better because otherwise the mental model for how to map pixels to the Arch is more difficult.