### PR TITLE
Rotate frame data received from WebAssembly Studio by 180 degrees

### DIFF
--- a/src/components/ArchwayPanel.js
+++ b/src/components/ArchwayPanel.js
@@ -40,6 +40,7 @@ export default class ArchwayPanel extends Component {
       "models/PreppedInstallation.obj",
       object => {
         object.position.set(0, -1.5, -8.5);
+        object.rotation.y = Math.PI;
         this.scene.add(object);
         for (let material of object.children[0].material) {
           this.materials.set(material.name, material);

--- a/src/utils/RenderUtils.js
+++ b/src/utils/RenderUtils.js
@@ -106,6 +106,8 @@ module.exports.animationBuffer2data = function (buffer, rows, cols, frames) {
             data[destOffset + 3] = 0xFF;
         }
 
+        new Uint32Array(data.buffer).reverse();
+
         result.push(imageData);
     }
 


### PR DESCRIPTION
The mapping of pixels to the Arch is highly unintuitive, and we want to avoid exposing this to users. The mapping is much easier to reason about if the pixels are rotated by 180 degrees, i.e. if the first pixel becomes the last, and vice versa.

The previewer has the inverse mapping, so to keep that the way it should be, we just rotate the 3D model by 180 degrees.